### PR TITLE
Update `required-fields` plugin

### DIFF
--- a/cmd/buf-plugin-required-fields/main_test.go
+++ b/cmd/buf-plugin-required-fields/main_test.go
@@ -43,13 +43,35 @@ func TestSimpleFailureWithOption(t *testing.T) {
 		ExpectedAnnotations: []checktest.ExpectedAnnotation{
 			{
 				RuleID:  requiredEntityFieldsRuleID,
-				Message: "\"BookCategory\" is missing required fields: [category]",
+				Message: "field \"updated_at\" is discouraged, use \"last_modified_at\" instead",
 				FileLocation: &checktest.ExpectedFileLocation{
 					FileName:    "simple.proto",
-					StartLine:   51,
+					StartLine:   50,
+					StartColumn: 4,
+					EndLine:     50,
+					EndColumn:   45,
+				},
+			},
+			{
+				RuleID:  requiredEntityFieldsRuleID,
+				Message: "message \"BookCategory\" is missing required fields: [category]",
+				FileLocation: &checktest.ExpectedFileLocation{
+					FileName:    "simple.proto",
+					StartLine:   53,
 					StartColumn: 0,
-					EndLine:     56,
+					EndLine:     60,
 					EndColumn:   1,
+				},
+			},
+			{
+				RuleID:  requiredEntityFieldsRuleID,
+				Message: "field \"last_updated_at\" is discouraged, use \"last_modified_at\" instead",
+				FileLocation: &checktest.ExpectedFileLocation{
+					FileName:    "simple.proto",
+					StartLine:   59,
+					StartColumn: 4,
+					EndLine:     59,
+					EndColumn:   50,
 				},
 			},
 		},
@@ -70,29 +92,51 @@ func TestSimpleFailure(t *testing.T) {
 		ExpectedAnnotations: []checktest.ExpectedAnnotation{
 			{
 				RuleID:  requiredEntityFieldsRuleID,
-				Message: "\"Book\" is missing required fields: [id account_id created_at]",
+				Message: "message \"Book\" is missing required fields: [id account_id created_at]",
 				FileLocation: &checktest.ExpectedFileLocation{
 					FileName:    "simple.proto",
 					StartLine:   42,
 					StartColumn: 0,
-					EndLine:     49,
+					EndLine:     51,
 					EndColumn:   1,
 				},
 			},
 			{
 				RuleID:  requiredEntityFieldsRuleID,
-				Message: "\"BookCategory\" is missing required fields: [name]",
+				Message: "field \"updated_at\" is discouraged, use \"last_modified_at\" instead",
 				FileLocation: &checktest.ExpectedFileLocation{
 					FileName:    "simple.proto",
-					StartLine:   51,
+					StartLine:   50,
+					StartColumn: 4,
+					EndLine:     50,
+					EndColumn:   45,
+				},
+			},
+			{
+				RuleID:  requiredEntityFieldsRuleID,
+				Message: "message \"BookCategory\" is missing required fields: [name]",
+				FileLocation: &checktest.ExpectedFileLocation{
+					FileName:    "simple.proto",
+					StartLine:   53,
 					StartColumn: 0,
-					EndLine:     56,
+					EndLine:     60,
 					EndColumn:   1,
 				},
 			},
 			{
+				RuleID:  requiredEntityFieldsRuleID,
+				Message: "field \"last_updated_at\" is discouraged, use \"last_modified_at\" instead",
+				FileLocation: &checktest.ExpectedFileLocation{
+					FileName:    "simple.proto",
+					StartLine:   59,
+					StartColumn: 4,
+					EndLine:     59,
+					EndColumn:   50,
+				},
+			},
+			{
 				RuleID:  requiredRequestFieldsRuleID,
-				Message: "\"ListBooksRequest\" is missing required fields: [account_id]",
+				Message: "message \"ListBooksRequest\" is missing required fields: [account_id]",
 				FileLocation: &checktest.ExpectedFileLocation{
 					FileName:    "simple.proto",
 					StartLine:   17,
@@ -103,7 +147,7 @@ func TestSimpleFailure(t *testing.T) {
 			},
 			{
 				RuleID:  requiredRequestFieldsRuleID,
-				Message: "\"GetBookRequest\" is missing required fields: [account_id]",
+				Message: "message \"GetBookRequest\" is missing required fields: [account_id]",
 				FileLocation: &checktest.ExpectedFileLocation{
 					FileName:    "simple.proto",
 					StartLine:   25,

--- a/cmd/buf-plugin-required-fields/testdata/simple_failure/simple.proto
+++ b/cmd/buf-plugin-required-fields/testdata/simple_failure/simple.proto
@@ -47,6 +47,8 @@ message Book {
     // missing `created_at` field
     BookCategory category = 2;
     Publisher publisher = 3;
+    // updated_at instead of last_modified_at
+    google.protobuf.Timestamp updated_at = 4;
 }
 
 message BookCategory {
@@ -54,6 +56,8 @@ message BookCategory {
     // missing `name` field
     string account_id = 2;
     google.protobuf.Timestamp created_at = 3;
+    // last_updated_at instead of last_modified_at
+    google.protobuf.Timestamp last_updated_at = 4;
 }
 
 // this message does not have any related CRUD method, we don't consider it an entity and


### PR DESCRIPTION
With this change, the plugin now also validates the name of the fields against a set of preferred field names. For instance, the linting will fail if you try to define a field named `updated_at` and will recommend you to use `last_modified_at`.

Example:
```
proto/qdrant/cloud/iam/v1/iam.proto:237:3:field "last_updated_at" is discouraged, use "last_modified_at" instead (buf-plugin-required-fields)
```


At this moment I considered it isn't worth to add this functionality as a new plugin, in the future we could either rename the plugin or split the functionality.