### PR TITLE
Update `buf-plugin-method-options` handling special case

### DIFF
--- a/cmd/buf-plugin-method-options/main_test.go
+++ b/cmd/buf-plugin-method-options/main_test.go
@@ -59,6 +59,28 @@ func TestSimpleFailure(t *testing.T) {
 					EndColumn:   5,
 				},
 			},
+			{
+				RuleID:  methodOptionsRuleID,
+				Message: "Method \"simple.GreeterService.ClosedGoodbye\" does not define the \"google.api.http\" option",
+				FileLocation: &checktest.ExpectedFileLocation{
+					FileName:    "simple.proto",
+					StartLine:   14,
+					StartColumn: 4,
+					EndLine:     18,
+					EndColumn:   5,
+				},
+			},
+			{
+				RuleID:  methodOptionsRuleID,
+				Message: "Method \"simple.GreeterService.ClosedGoodbye\" does not define the \"qdrant.cloud.common.v1.permissions\" option",
+				FileLocation: &checktest.ExpectedFileLocation{
+					FileName:    "simple.proto",
+					StartLine:   14,
+					StartColumn: 4,
+					EndLine:     18,
+					EndColumn:   5,
+				},
+			},
 		},
 	}.Run(t)
 }
@@ -83,12 +105,27 @@ func TestSimpleFailureWithOption(t *testing.T) {
 			},
 			{
 				RuleID:  methodOptionsRuleID,
+				Message: "extension key \"unknown.extension\" does not exist",
+			},
+			{
+				RuleID:  methodOptionsRuleID,
 				Message: "Method \"simple.GreeterService.HelloWorld\" does not define the \"qdrant.cloud.common.v1.permissions\" option",
 				FileLocation: &checktest.ExpectedFileLocation{
 					FileName:    "simple.proto",
 					StartLine:   9,
 					StartColumn: 4,
 					EndLine:     12,
+					EndColumn:   5,
+				},
+			},
+			{
+				RuleID:  methodOptionsRuleID,
+				Message: "Method \"simple.GreeterService.ClosedGoodbye\" does not define the \"qdrant.cloud.common.v1.permissions\" option",
+				FileLocation: &checktest.ExpectedFileLocation{
+					FileName:    "simple.proto",
+					StartLine:   14,
+					StartColumn: 4,
+					EndLine:     18,
 					EndColumn:   5,
 				},
 			},
@@ -111,6 +148,10 @@ func TestSimpleFailureWithOptionWrongKey(t *testing.T) {
 		},
 		Spec: spec,
 		ExpectedAnnotations: []checktest.ExpectedAnnotation{
+			{
+				RuleID:  methodOptionsRuleID,
+				Message: "extension key \"unknown.extension\" does not exist",
+			},
 			{
 				RuleID:  methodOptionsRuleID,
 				Message: "extension key \"unknown.extension\" does not exist",

--- a/cmd/buf-plugin-method-options/testdata/common.proto
+++ b/cmd/buf-plugin-method-options/testdata/common.proto
@@ -11,3 +11,10 @@ extend google.protobuf.MethodOptions {
     // A list of permissions which ALL need to be met by the current user.
     repeated string permissions = 50001;
 }
+
+// The extension for allowing a method to be be used without authentication.
+// If the extension is missing the system requires authentication and return a 'permission denied' error if missing.
+extend google.protobuf.MethodOptions {
+    // Set to allow a method to be used without authentication.
+    bool requires_authentication = 50003;
+}

--- a/cmd/buf-plugin-method-options/testdata/simple_failure/simple.proto
+++ b/cmd/buf-plugin-method-options/testdata/simple_failure/simple.proto
@@ -11,4 +11,10 @@ service GreeterService {
         // missing qdrant.cloud.common.v1.permissions
         // missing google.api.http
     }
+
+    rpc ClosedGoodbye(google.protobuf.Empty) returns (google.protobuf.Empty) {
+        option (qdrant.cloud.common.v1.requires_authentication) = true;
+        // missing qdrant.cloud.common.v1.permissions
+        // missing google.api.http
+    }
 }

--- a/cmd/buf-plugin-method-options/testdata/simple_success/simple.proto
+++ b/cmd/buf-plugin-method-options/testdata/simple_success/simple.proto
@@ -13,4 +13,11 @@ service GreeterService {
         option (qdrant.cloud.common.v1.permissions) = "read:api_keys";
         option (google.api.http) = {get: "/api/hello-world"};
     }
+
+    rpc OpenGoodbye(google.protobuf.Empty) returns (google.protobuf.Empty) {
+        // there aren't permissions required because it doesn't require
+        // authentication.
+        option (qdrant.cloud.common.v1.requires_authentication) = false;
+        option (google.api.http) = {get: "/api/hello-world"};
+    }
 }


### PR DESCRIPTION
The behavior of the "qdrant.cloud.common.v1.permissions" option depends on another option "qdrant.cloud.common.requires_authentication". With this change, we handle this special case: When `requires_authentication` is set to false, we don't validate the presence of the `permissions` option.