### PR TITLE
Update buf-plugin-method-options with a new check

### DIFF
--- a/cmd/buf-plugin-method-options/main_test.go
+++ b/cmd/buf-plugin-method-options/main_test.go
@@ -160,3 +160,44 @@ func TestSimpleFailureWithOptionWrongKey(t *testing.T) {
 	}.Run(t)
 
 }
+
+func TestPermissionsConflictSuccess(t *testing.T) {
+	t.Parallel()
+
+	checktest.CheckTest{
+		Request: &checktest.RequestSpec{
+			Files: &checktest.ProtoFileSpec{
+				DirPaths:  []string{"testdata/permissions_conflict_success"},
+				FilePaths: []string{"valid.proto"},
+			},
+		},
+		Spec: spec,
+	}.Run(t)
+}
+
+func TestPermissionsConflictFailure(t *testing.T) {
+	t.Parallel()
+
+	checktest.CheckTest{
+		Request: &checktest.RequestSpec{
+			Files: &checktest.ProtoFileSpec{
+				DirPaths:  []string{"testdata/permissions_conflict_failure"},
+				FilePaths: []string{"invalid.proto"},
+			},
+		},
+		Spec: spec,
+		ExpectedAnnotations: []checktest.ExpectedAnnotation{
+			{
+				RuleID:  methodOptionsRuleID,
+				Message: "Method \"invalid.GreeterService.HelloWorldWithConflict\" has permissions set but account_id_expression is empty. Methods with permissions require a non-empty account_id_expression since permissions are checked in the scope of the account",
+				FileLocation: &checktest.ExpectedFileLocation{
+					FileName:    "invalid.proto",
+					StartLine:   10,
+					StartColumn: 4,
+					EndLine:     15,
+					EndColumn:   5,
+				},
+			},
+		},
+	}.Run(t)
+}

--- a/cmd/buf-plugin-method-options/testdata/common.proto
+++ b/cmd/buf-plugin-method-options/testdata/common.proto
@@ -12,6 +12,15 @@ extend google.protobuf.MethodOptions {
     repeated string permissions = 50001;
 }
 
+// The extension for adding an expression where to find the account ID in a message
+// If the extension is missing 'account_id' will be used.
+extend google.protobuf.MethodOptions {
+    // The expression to find the account ID field, which should be a string field.
+    // It is allowed to nest fields with a point, like 'cluster.account_id' or 'account.id'
+    // If the expression is set to an empty string, no account ID will be used.
+    string account_id_expression = 50002;
+}
+
 // The extension for allowing a method to be be used without authentication.
 // If the extension is missing the system requires authentication and return a 'permission denied' error if missing.
 extend google.protobuf.MethodOptions {

--- a/cmd/buf-plugin-method-options/testdata/permissions_conflict_failure/invalid.proto
+++ b/cmd/buf-plugin-method-options/testdata/permissions_conflict_failure/invalid.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package invalid;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/descriptor.proto";
+import "../common.proto";
+import "../google.proto";
+
+service GreeterService {
+    rpc HelloWorldWithConflict(google.protobuf.Empty) returns (google.protobuf.Empty) {
+        // This should fail: permissions set with empty account_id_expression
+        option (qdrant.cloud.common.v1.permissions) = "write:user";
+        option (qdrant.cloud.common.v1.account_id_expression) = "";
+        option (google.api.http) = {get: "/api/hello-world-conflict"};
+    }
+}

--- a/cmd/buf-plugin-method-options/testdata/permissions_conflict_success/valid.proto
+++ b/cmd/buf-plugin-method-options/testdata/permissions_conflict_success/valid.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package valid;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/descriptor.proto";
+import "../common.proto";
+import "../google.proto";
+
+service GreeterService {
+    rpc HelloWorldWithValidAccount(google.protobuf.Empty) returns (google.protobuf.Empty) {
+        // This should pass: permissions set with valid account_id_expression
+        option (qdrant.cloud.common.v1.permissions) = "write:user";
+        option (qdrant.cloud.common.v1.account_id_expression) = "request.account_id";
+        option (google.api.http) = {get: "/api/hello-world-valid"};
+    }
+
+    rpc HelloWorldNoPermissions(google.protobuf.Empty) returns (google.protobuf.Empty) {
+        // This should pass: no permissions, empty account_id_expression is ok
+        option (qdrant.cloud.common.v1.permissions) = "";
+        option (qdrant.cloud.common.v1.account_id_expression) = "";
+        option (google.api.http) = {get: "/api/hello-world-no-perms"};
+    }
+}


### PR DESCRIPTION
Add a check to validate that the `permissions` option isn't empty if the method also contains an empty `account_id_expression`.

This is an example of running it against the public-api:

```
proto/qdrant/cloud/iam/v1/iam.proto:38:3:Method "qdrant.cloud.iam.v1.IAMService.UpdateUser" has permissions set but account_id_expression is empty. Methods with permissions require a non-empty account_id_expression since permissions are checked in the scope of the account (buf-plugin-method-options)
proto/qdrant/cloud/iam/v1/iam.proto:77:3:Method "qdrant.cloud.iam.v1.IAMService.RecordUserConsent" has permissions set but account_id_expression is empty. Methods with permissions require a non-empty account_id_expression since permissions are checked in the scope of the account (buf-plugin-method-options)
```