### PR TITLE
Add plugin to detect breaking changes in permissions

### DIFF
--- a/cmd/buf-plugin-permissions-breaking/main.go
+++ b/cmd/buf-plugin-permissions-breaking/main.go
@@ -1,0 +1,223 @@
+// Package main implements a plugin that checks for breaking changes in permissions.
+// The plugin detects when method permissions change, which could break existing
+// client code that depends on certain access levels.
+//
+// The plugin handles both AND and OR permission logic via the requires_all_permissions option:
+// - requires_all_permissions=true (default): ALL permissions must be met (AND logic)
+// - requires_all_permissions=false: ANY ONE permission must be met (OR logic)
+//
+// Breaking changes detected:
+// - Adding permissions to methods that previously had none (restricts access)
+// - Removing all permissions from methods (changes access model)
+// - Changing requires_all_permissions from false to true (OR to AND, more restrictive)
+// - For AND permissions (requires_all_permissions=true): ANY change to permissions
+// - For OR permissions (requires_all_permissions=false): REMOVING permissions
+//
+// Non-breaking changes (not reported):
+// - New methods with permissions (handled automatically by buf framework)
+// - Changing requires_all_permissions from true to false (AND to OR, more permissive)
+// - For OR permissions (requires_all_permissions=false): ADDING permissions
+//
+// To use this plugin:
+//
+//	# buf.yaml
+//	version: v2
+//	breaking:
+//	  use:
+//	   - QDRANT_CLOUD_PERMISSIONS_BREAKING
+//	plugins:
+//	  - plugin: buf-plugin-permissions-breaking
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"buf.build/go/bufplugin/check"
+	"buf.build/go/bufplugin/check/checkutil"
+	"buf.build/go/bufplugin/info"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	commonv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/common/v1"
+)
+
+const (
+	permissionsBreakingRuleID = "QDRANT_CLOUD_PERMISSIONS_BREAKING"
+)
+
+// PermissionConfig holds the permission configuration for a method.
+type PermissionConfig struct {
+	Permissions []string
+	RequiresAll bool // true = AND (default), false = OR
+}
+
+var (
+	permissionsBreakingRuleSpec = &check.RuleSpec{
+		ID:      permissionsBreakingRuleID,
+		Default: true,
+		Purpose: `Checks for breaking changes in method permissions.`,
+		Type:    check.RuleTypeBreaking,
+		Handler: checkutil.NewMethodPairRuleHandler(checkPermissionsBreaking, checkutil.WithoutImports()),
+	}
+	spec = &check.Spec{
+		Rules: []*check.RuleSpec{
+			permissionsBreakingRuleSpec,
+		},
+		Info: &info.Spec{
+			Documentation: `A plugin that checks for breaking changes in method permissions.`,
+			SPDXLicenseID: "",
+			LicenseURL:    "",
+		},
+	}
+	permissionsOption            = commonv1.E_Permissions
+	requiresAllPermissionsOption = commonv1.E_RequiresAllPermissions
+)
+
+func main() {
+	check.Main(spec)
+}
+
+func checkPermissionsBreaking(ctx context.Context, responseWriter check.ResponseWriter, request check.Request, methodDescriptor, againstMethodDescriptor protoreflect.MethodDescriptor) error {
+	againstConfig := getMethodPermissionConfig(againstMethodDescriptor)
+	currentConfig := getMethodPermissionConfig(methodDescriptor)
+
+	// Check for breaking changes based on permission logic
+	if isBreakingChange(againstConfig, currentConfig) {
+		var message string
+		if len(currentConfig.Permissions) == 0 {
+			message = fmt.Sprintf("Method %q had permissions %v but now has no permissions, this is a breaking change",
+				methodDescriptor.FullName(), againstConfig.Permissions)
+		} else if len(againstConfig.Permissions) == 0 {
+			message = fmt.Sprintf("Method %q had no permissions but now requires permissions %v, this is a breaking change",
+				methodDescriptor.FullName(), currentConfig.Permissions)
+		} else {
+			requiresAllChanged := againstConfig.RequiresAll != currentConfig.RequiresAll
+			if requiresAllChanged {
+				message = fmt.Sprintf("Method %q permissions logic changed from requires_all=%t to requires_all=%t with permissions %v to %v, this is a breaking change",
+					methodDescriptor.FullName(), againstConfig.RequiresAll, currentConfig.RequiresAll, againstConfig.Permissions, currentConfig.Permissions)
+			} else {
+				message = fmt.Sprintf("Method %q permissions changed from %v to %v (requires_all=%t), this is a breaking change",
+					methodDescriptor.FullName(), againstConfig.Permissions, currentConfig.Permissions, currentConfig.RequiresAll)
+			}
+		}
+		responseWriter.AddAnnotation(
+			check.WithMessage(message),
+			check.WithDescriptor(methodDescriptor),
+		)
+	}
+
+	return nil
+}
+
+// getMethodPermissionConfig extracts the permission configuration from a method descriptor.
+func getMethodPermissionConfig(methodDescriptor protoreflect.MethodDescriptor) PermissionConfig {
+	options := methodDescriptor.Options()
+
+	// Extract permissions
+	var permissions []string
+	if proto.HasExtension(options, permissionsOption) {
+		permissionsRaw := proto.GetExtension(options, permissionsOption)
+		if permissionsSlice, ok := permissionsRaw.([]string); ok {
+			// Filter out empty permissions and sort for consistent comparison
+			for _, perm := range permissionsSlice {
+				if strings.TrimSpace(perm) != "" {
+					permissions = append(permissions, strings.TrimSpace(perm))
+				}
+			}
+			sort.Strings(permissions)
+		}
+	}
+
+	// Extract requires_all_permissions (defaults to true)
+	requiresAll := true // Default to AND behavior
+	if proto.HasExtension(options, requiresAllPermissionsOption) {
+		if val, ok := proto.GetExtension(options, requiresAllPermissionsOption).(bool); ok {
+			requiresAll = val
+		}
+	}
+
+	return PermissionConfig{
+		Permissions: permissions,
+		RequiresAll: requiresAll,
+	}
+}
+
+// isBreakingChange determines if a permission configuration change is breaking.
+func isBreakingChange(against, current PermissionConfig) bool {
+	// If both configs are identical, no breaking change
+	if configsEqual(against, current) {
+		return false
+	}
+
+	// If requires_all_permissions logic changed:
+	// - true -> false (AND to OR): non-breaking (more permissive)
+	// - false -> true (OR to AND): breaking (more restrictive)
+	if against.RequiresAll != current.RequiresAll {
+		if against.RequiresAll && !current.RequiresAll {
+			// Changed from AND to OR - non-breaking (more permissive)
+			return false
+		} else {
+			// Changed from OR to AND - breaking (more restrictive)
+			return true
+		}
+	}
+
+	// Handle the case where permissions are added to a method that had none
+	if len(against.Permissions) == 0 && len(current.Permissions) > 0 {
+		return true // Adding permissions to a previously unrestricted method is breaking
+	}
+
+	// Handle the case where permissions are removed completely
+	if len(against.Permissions) > 0 && len(current.Permissions) == 0 {
+		return true // Removing all permissions changes the access model
+	}
+
+	// For methods that had permissions before and still have permissions
+	if len(against.Permissions) > 0 && len(current.Permissions) > 0 {
+		if against.RequiresAll {
+			// AND logic: ANY change is breaking (both adding and removing permissions)
+			return !permissionsEqual(against.Permissions, current.Permissions)
+		} else {
+			// OR logic: Only removing permissions is breaking, adding is non-breaking
+			return hasRemovedPermissions(against.Permissions, current.Permissions)
+		}
+	}
+
+	return false
+}
+
+// configsEqual checks if two permission configurations are identical.
+func configsEqual(a, b PermissionConfig) bool {
+	return a.RequiresAll == b.RequiresAll && permissionsEqual(a.Permissions, b.Permissions)
+}
+
+// hasRemovedPermissions checks if any permissions were removed (for OR logic).
+func hasRemovedPermissions(previous, current []string) bool {
+	currentSet := make(map[string]bool)
+	for _, perm := range current {
+		currentSet[perm] = true
+	}
+
+	for _, perm := range previous {
+		if !currentSet[perm] {
+			return true // Found a permission that was removed
+		}
+	}
+	return false
+}
+
+func permissionsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/buf-plugin-permissions-breaking/main_test.go
+++ b/cmd/buf-plugin-permissions-breaking/main_test.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"testing"
+
+	"buf.build/go/bufplugin/check/checktest"
+)
+
+func TestSpec(t *testing.T) {
+	t.Parallel()
+	checktest.SpecTest(t, spec)
+}
+
+func TestBreakingChange(t *testing.T) {
+	t.Parallel()
+
+	checktest.CheckTest{
+		Request: &checktest.RequestSpec{
+			Files: &checktest.ProtoFileSpec{
+				DirPaths:  []string{"testdata/breaking_change/current"},
+				FilePaths: []string{"service.proto"},
+			},
+			AgainstFiles: &checktest.ProtoFileSpec{
+				DirPaths:  []string{"testdata/breaking_change/previous"},
+				FilePaths: []string{"service.proto"},
+			},
+		},
+		Spec: spec,
+		ExpectedAnnotations: []checktest.ExpectedAnnotation{
+			{
+				RuleID:  permissionsBreakingRuleID,
+				Message: "Method \"test.TestService.TestMethod\" permissions changed from [read:test write:test] to [read:test] (requires_all=true), this is a breaking change",
+				FileLocation: &checktest.ExpectedFileLocation{
+					FileName:    "service.proto",
+					StartLine:   9,
+					StartColumn: 2,
+					EndLine:     11,
+					EndColumn:   3,
+				},
+			},
+		},
+	}.Run(t)
+}
+
+func TestNewMethodNonBreaking(t *testing.T) {
+	t.Parallel()
+
+	checktest.CheckTest{
+		Request: &checktest.RequestSpec{
+			Files: &checktest.ProtoFileSpec{
+				DirPaths:  []string{"testdata/new_method/current"},
+				FilePaths: []string{"service.proto"},
+			},
+			AgainstFiles: &checktest.ProtoFileSpec{
+				DirPaths:  []string{"testdata/new_method/previous"},
+				FilePaths: []string{"service.proto"},
+			},
+		},
+		Spec: spec,
+		// No expected annotations - new methods with permissions should not be breaking
+	}.Run(t)
+}
+
+func TestAddPermissionsBreaking(t *testing.T) {
+	t.Parallel()
+
+	checktest.CheckTest{
+		Request: &checktest.RequestSpec{
+			Files: &checktest.ProtoFileSpec{
+				DirPaths:  []string{"testdata/add_permissions/current"},
+				FilePaths: []string{"service.proto"},
+			},
+			AgainstFiles: &checktest.ProtoFileSpec{
+				DirPaths:  []string{"testdata/add_permissions/previous"},
+				FilePaths: []string{"service.proto"},
+			},
+		},
+		Spec: spec,
+		ExpectedAnnotations: []checktest.ExpectedAnnotation{
+			{
+				RuleID:  permissionsBreakingRuleID,
+				Message: "Method \"test.TestService.PublicMethod\" had no permissions but now requires permissions [read:restricted], this is a breaking change",
+				FileLocation: &checktest.ExpectedFileLocation{
+					FileName:    "service.proto",
+					StartLine:   9,
+					StartColumn: 2,
+					EndLine:     11,
+					EndColumn:   3,
+				},
+			},
+		},
+	}.Run(t)
+}
+
+func TestOrPermissionsAddNonBreaking(t *testing.T) {
+	t.Parallel()
+
+	checktest.CheckTest{
+		Request: &checktest.RequestSpec{
+			Files: &checktest.ProtoFileSpec{
+				DirPaths:  []string{"testdata/or_permissions_add_non_breaking/current"},
+				FilePaths: []string{"service.proto"},
+			},
+			AgainstFiles: &checktest.ProtoFileSpec{
+				DirPaths:  []string{"testdata/or_permissions_add_non_breaking/previous"},
+				FilePaths: []string{"service.proto"},
+			},
+		},
+		Spec: spec,
+		// No expected annotations - adding permissions with OR logic is non-breaking
+	}.Run(t)
+}
+
+func TestOrPermissionsRemoveBreaking(t *testing.T) {
+	t.Parallel()
+
+	checktest.CheckTest{
+		Request: &checktest.RequestSpec{
+			Files: &checktest.ProtoFileSpec{
+				DirPaths:  []string{"testdata/or_permissions_remove_breaking/current"},
+				FilePaths: []string{"service.proto"},
+			},
+			AgainstFiles: &checktest.ProtoFileSpec{
+				DirPaths:  []string{"testdata/or_permissions_remove_breaking/previous"},
+				FilePaths: []string{"service.proto"},
+			},
+		},
+		Spec: spec,
+		ExpectedAnnotations: []checktest.ExpectedAnnotation{
+			{
+				RuleID:  permissionsBreakingRuleID,
+				Message: "Method \"test.TestService.FlexibleMethod\" permissions changed from [read:advanced read:basic] to [read:basic] (requires_all=false), this is a breaking change",
+				FileLocation: &checktest.ExpectedFileLocation{
+					FileName:    "service.proto",
+					StartLine:   9,
+					StartColumn: 2,
+					EndLine:     12,
+					EndColumn:   3,
+				},
+			},
+		},
+	}.Run(t)
+}
+
+func TestAndToOrNonBreaking(t *testing.T) {
+	t.Parallel()
+
+	checktest.CheckTest{
+		Request: &checktest.RequestSpec{
+			Files: &checktest.ProtoFileSpec{
+				DirPaths:  []string{"testdata/and_to_or_non_breaking/current"},
+				FilePaths: []string{"service.proto"},
+			},
+			AgainstFiles: &checktest.ProtoFileSpec{
+				DirPaths:  []string{"testdata/and_to_or_non_breaking/previous"},
+				FilePaths: []string{"service.proto"},
+			},
+		},
+		Spec: spec,
+		// No expected annotations - changing from AND to OR is non-breaking (more permissive)
+	}.Run(t)
+}
+
+func TestOrToAndBreaking(t *testing.T) {
+	t.Parallel()
+
+	checktest.CheckTest{
+		Request: &checktest.RequestSpec{
+			Files: &checktest.ProtoFileSpec{
+				DirPaths:  []string{"testdata/or_to_and_breaking/current"},
+				FilePaths: []string{"service.proto"},
+			},
+			AgainstFiles: &checktest.ProtoFileSpec{
+				DirPaths:  []string{"testdata/or_to_and_breaking/previous"},
+				FilePaths: []string{"service.proto"},
+			},
+		},
+		Spec: spec,
+		ExpectedAnnotations: []checktest.ExpectedAnnotation{
+			{
+				RuleID:  permissionsBreakingRuleID,
+				Message: "Method \"test.TestService.MyMethod\" permissions logic changed from requires_all=false to requires_all=true with permissions [read:data write:data] to [read:data write:data], this is a breaking change",
+				FileLocation: &checktest.ExpectedFileLocation{
+					FileName:    "service.proto",
+					StartLine:   9,
+					StartColumn: 2,
+					EndLine:     13,
+					EndColumn:   3,
+				},
+			},
+		},
+	}.Run(t)
+}

--- a/cmd/buf-plugin-permissions-breaking/testdata/add_permissions/current/service.proto
+++ b/cmd/buf-plugin-permissions-breaking/testdata/add_permissions/current/service.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package test;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/descriptor.proto";
+import "../../common.proto";
+
+service TestService {
+  rpc PublicMethod(google.protobuf.Empty) returns (google.protobuf.Empty) {
+    option (qdrant.cloud.common.v1.permissions) = "read:restricted";
+  }
+}

--- a/cmd/buf-plugin-permissions-breaking/testdata/add_permissions/previous/service.proto
+++ b/cmd/buf-plugin-permissions-breaking/testdata/add_permissions/previous/service.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package test;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/descriptor.proto";
+import "../../common.proto";
+
+service TestService {
+  rpc PublicMethod(google.protobuf.Empty) returns (google.protobuf.Empty) {
+    // No permissions - this method was publicly accessible
+  }
+}

--- a/cmd/buf-plugin-permissions-breaking/testdata/and_to_or_non_breaking/current/service.proto
+++ b/cmd/buf-plugin-permissions-breaking/testdata/and_to_or_non_breaking/current/service.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package test;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/descriptor.proto";
+import "../../common.proto";
+
+service TestService {
+  rpc MyMethod(google.protobuf.Empty) returns (google.protobuf.Empty) {
+    option (qdrant.cloud.common.v1.permissions) = "read:data";
+    option (qdrant.cloud.common.v1.permissions) = "write:data";
+    option (qdrant.cloud.common.v1.requires_all_permissions) = false; // OR
+  }
+}

--- a/cmd/buf-plugin-permissions-breaking/testdata/and_to_or_non_breaking/previous/service.proto
+++ b/cmd/buf-plugin-permissions-breaking/testdata/and_to_or_non_breaking/previous/service.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package test;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/descriptor.proto";
+import "../../common.proto";
+
+service TestService {
+  rpc MyMethod(google.protobuf.Empty) returns (google.protobuf.Empty) {
+    option (qdrant.cloud.common.v1.permissions) = "read:data";
+    option (qdrant.cloud.common.v1.permissions) = "write:data";
+    option (qdrant.cloud.common.v1.requires_all_permissions) = true; // AND
+  }
+}

--- a/cmd/buf-plugin-permissions-breaking/testdata/breaking_change/current/service.proto
+++ b/cmd/buf-plugin-permissions-breaking/testdata/breaking_change/current/service.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package test;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/descriptor.proto";
+import "../../common.proto";
+
+service TestService {
+  rpc TestMethod(google.protobuf.Empty) returns (google.protobuf.Empty) {
+    option (qdrant.cloud.common.v1.permissions) = "read:test";
+  }
+}

--- a/cmd/buf-plugin-permissions-breaking/testdata/breaking_change/previous/service.proto
+++ b/cmd/buf-plugin-permissions-breaking/testdata/breaking_change/previous/service.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package test;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/descriptor.proto";
+import "../../common.proto";
+
+service TestService {
+  rpc TestMethod(google.protobuf.Empty) returns (google.protobuf.Empty) {
+    option (qdrant.cloud.common.v1.permissions) = "read:test";
+    option (qdrant.cloud.common.v1.permissions) = "write:test";
+  }
+}

--- a/cmd/buf-plugin-permissions-breaking/testdata/common.proto
+++ b/cmd/buf-plugin-permissions-breaking/testdata/common.proto
@@ -1,0 +1,62 @@
+syntax = "proto3";
+
+package qdrant.cloud.common.v1;
+
+import "google/protobuf/descriptor.proto";
+
+// The extension for adding permissions to the system
+extend google.protobuf.MethodOptions {
+    // A list of permissions which need to be met by the current user.
+    // If `requires_all_permissions` is true (or missing): ALL of the permissions should be met (and)
+    // If `requires_all_permissions` is false: ANY-OF the permissions should be met (or)
+    repeated string permissions = 50001;
+}
+
+// The extension for adding an expression where to find the account ID in a message
+// If the extension is missing 'account_id' will be used.
+extend google.protobuf.MethodOptions {
+    // The expression to find the account ID field, which should be a string field.
+    // It is allowed to nest fields with a point, like 'cluster.account_id' or 'account.id'
+    // If the expression is set to an empty string, no account ID will be used.
+    string account_id_expression = 50002;
+}
+
+// The extension for allowing a method to be be used without authentication.
+// If the extension is missing the system requires authentication and return a 'permission denied' error if missing.
+extend google.protobuf.MethodOptions {
+    // Set to allow a method to be used without authentication.
+    bool requires_authentication = 50003;
+}
+
+// The extension for allowing a method to be be used with specific actor types.
+// If the extension is missing the system allows all actor types.
+extend google.protobuf.MethodOptions {
+    // If this option is set, only the specified actor types are allowed to call the method.
+    // If empty or not set, all authenticated actor types (that pass other permission checks) are allowed.
+    repeated ActorType supported_actor_types = 50004 [
+        packed = true
+    ];
+}
+
+// The extension for switching `permissions` from ALL to ANY-OF
+// If the extension is missing 'true' will be used (defaulting to ALL).
+extend google.protobuf.MethodOptions {
+  // If set to true the provided permissions are ALL (and)
+  // if set to false the provided permissions are ANY-OF (or).
+  bool requires_all_permissions = 50005;
+}
+
+// ActorType specifies the type of actor that can call a method.
+enum ActorType {
+  // Default, unspecified actor type. Should generally not be used explicitly in options
+  // unless to signify an error or uninitialized state.
+  ACTOR_TYPE_UNSPECIFIED = 0;
+  // Represents a human user, typically authenticated via an identity provider (Auth0).
+  ACTOR_TYPE_USER = 1;
+  // Represents a programmatic access key, also called management key,
+  // that is not be tied to a specific user or service account identity, but rather an account.
+  ACTOR_TYPE_MANAGEMENT_KEY = 2;
+  // Represents a service account or machine user, often used for M2M communication.
+  // This is for internal platform use only.
+  ACTOR_TYPE_SERVICE_ACCOUNT = 3;
+}

--- a/cmd/buf-plugin-permissions-breaking/testdata/google.proto
+++ b/cmd/buf-plugin-permissions-breaking/testdata/google.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+// As a commodity, we re-define it here to avoid relying on the real dependency.
+
+package google.api;
+
+import "google/protobuf/descriptor.proto";
+
+extend google.protobuf.MethodOptions {
+    HttpRule http = 72295728;
+}
+
+message HttpRule {
+    string get = 1;
+}

--- a/cmd/buf-plugin-permissions-breaking/testdata/new_method/current/service.proto
+++ b/cmd/buf-plugin-permissions-breaking/testdata/new_method/current/service.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package test;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/descriptor.proto";
+import "../../common.proto";
+
+service TestService {
+  rpc ExistingMethod(google.protobuf.Empty) returns (google.protobuf.Empty) {
+    option (qdrant.cloud.common.v1.permissions) = "read:existing";
+  }
+
+  rpc NewMethod(google.protobuf.Empty) returns (google.protobuf.Empty) {
+    option (qdrant.cloud.common.v1.permissions) = "read:new";
+    option (qdrant.cloud.common.v1.permissions) = "write:new";
+  }
+}

--- a/cmd/buf-plugin-permissions-breaking/testdata/new_method/previous/service.proto
+++ b/cmd/buf-plugin-permissions-breaking/testdata/new_method/previous/service.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package test;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/descriptor.proto";
+import "../../common.proto";
+
+service TestService {
+  rpc ExistingMethod(google.protobuf.Empty) returns (google.protobuf.Empty) {
+    option (qdrant.cloud.common.v1.permissions) = "read:existing";
+  }
+}

--- a/cmd/buf-plugin-permissions-breaking/testdata/or_permissions_add_non_breaking/current/service.proto
+++ b/cmd/buf-plugin-permissions-breaking/testdata/or_permissions_add_non_breaking/current/service.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package test;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/descriptor.proto";
+import "../../common.proto";
+
+service TestService {
+  rpc FlexibleMethod(google.protobuf.Empty) returns (google.protobuf.Empty) {
+    option (qdrant.cloud.common.v1.permissions) = "read:basic";
+    option (qdrant.cloud.common.v1.permissions) = "read:advanced"; // Added permission
+    option (qdrant.cloud.common.v1.requires_all_permissions) = false; // OR logic
+  }
+}

--- a/cmd/buf-plugin-permissions-breaking/testdata/or_permissions_add_non_breaking/previous/service.proto
+++ b/cmd/buf-plugin-permissions-breaking/testdata/or_permissions_add_non_breaking/previous/service.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package test;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/descriptor.proto";
+import "../../common.proto";
+
+service TestService {
+  rpc FlexibleMethod(google.protobuf.Empty) returns (google.protobuf.Empty) {
+    option (qdrant.cloud.common.v1.permissions) = "read:basic";
+    option (qdrant.cloud.common.v1.requires_all_permissions) = false; // OR logic
+  }
+}

--- a/cmd/buf-plugin-permissions-breaking/testdata/or_permissions_remove_breaking/current/service.proto
+++ b/cmd/buf-plugin-permissions-breaking/testdata/or_permissions_remove_breaking/current/service.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package test;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/descriptor.proto";
+import "../../common.proto";
+
+service TestService {
+  rpc FlexibleMethod(google.protobuf.Empty) returns (google.protobuf.Empty) {
+    option (qdrant.cloud.common.v1.permissions) = "read:basic"; // Removed read:advanced
+    option (qdrant.cloud.common.v1.requires_all_permissions) = false; // OR logic
+  }
+}

--- a/cmd/buf-plugin-permissions-breaking/testdata/or_permissions_remove_breaking/previous/service.proto
+++ b/cmd/buf-plugin-permissions-breaking/testdata/or_permissions_remove_breaking/previous/service.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package test;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/descriptor.proto";
+import "../../common.proto";
+
+service TestService {
+  rpc FlexibleMethod(google.protobuf.Empty) returns (google.protobuf.Empty) {
+    option (qdrant.cloud.common.v1.permissions) = "read:basic";
+    option (qdrant.cloud.common.v1.permissions) = "read:advanced";
+    option (qdrant.cloud.common.v1.requires_all_permissions) = false; // OR logic
+  }
+}

--- a/cmd/buf-plugin-permissions-breaking/testdata/or_to_and_breaking/current/service.proto
+++ b/cmd/buf-plugin-permissions-breaking/testdata/or_to_and_breaking/current/service.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package test;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/descriptor.proto";
+import "../../common.proto";
+
+service TestService {
+  rpc MyMethod(google.protobuf.Empty) returns (google.protobuf.Empty) {
+    option (qdrant.cloud.common.v1.permissions) = "read:data";
+    option (qdrant.cloud.common.v1.permissions) = "write:data";
+    option (qdrant.cloud.common.v1.requires_all_permissions) = true; // AND
+  }
+}

--- a/cmd/buf-plugin-permissions-breaking/testdata/or_to_and_breaking/previous/service.proto
+++ b/cmd/buf-plugin-permissions-breaking/testdata/or_to_and_breaking/previous/service.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package test;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/descriptor.proto";
+import "../../common.proto";
+
+service TestService {
+  rpc MyMethod(google.protobuf.Empty) returns (google.protobuf.Empty) {
+    option (qdrant.cloud.common.v1.permissions) = "read:data";
+    option (qdrant.cloud.common.v1.permissions) = "write:data";
+    option (qdrant.cloud.common.v1.requires_all_permissions) = false; // OR
+  }
+}


### PR DESCRIPTION
These are some examples when making changes, see the tests for completeness.

Adding a new permission:
```
proto/qdrant/cloud/iam/v1/iam.proto:29:3:Method "qdrant.cloud.iam.v1.IAMService.ListUsers" permissions changed from [read:users] to [read:users write:users], this is a breaking change (buf-plugin-permissions-breaking)
```
Removing all permissions:
```
proto/qdrant/cloud/iam/v1/iam.proto:29:3:Method "qdrant.cloud.iam.v1.IAMService.ListUsers" had permissions [read:users] but now has no permissions, this is a breaking change (buf-plugin-permissions-breaking)
```

Changing from requires_all_permissions false -> true:
```
proto/qdrant/cloud/hybrid/v1/hybrid_cloud.proto:19:3:Method "qdrant.cloud.hybrid.v1.HybridCloudService.ListHybridCloudEnvironments" permissions logic changed from requires_all=false to requires_all=true with permissions [read:hybrid_cloud_environments write:clusters] to [read:hybrid_cloud_environments write:clusters], this is a breaking change (buf-plugin-permissions-breaking)
```